### PR TITLE
Fixed bug preventing multiple annotations of the same type per property

### DIFF
--- a/src/UoN.ExpressiveAnnotations.NetCore/UoN.ExpressiveAnnotations.NetCore.csproj
+++ b/src/UoN.ExpressiveAnnotations.NetCore/UoN.ExpressiveAnnotations.NetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageVersion>0.1.1-beta1</PackageVersion>
+    <PackageVersion>0.1.1</PackageVersion>
 
     <Authors>UoN Application Development</Authors>
 

--- a/src/UoN.ExpressiveAnnotations.NetCore/UoN.ExpressiveAnnotations.NetCore.csproj
+++ b/src/UoN.ExpressiveAnnotations.NetCore/UoN.ExpressiveAnnotations.NetCore.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageVersion>0.1.0</PackageVersion>
+    <PackageVersion>0.1.1-beta1</PackageVersion>
 
     <Authors>UoN Application Development</Authors>
 
     <Description>
-Fork of Jarosław Waliszko's Expressive Annotations .NET library, adding support for .NET Core. Expressive Annotations provides new flexible and powerful model validation attributes, to add to the attributes built in to .NET.
+Fork of Jarosław Waliszko's Expressive Annotations .NET library, adding support for client-side validation in .NET Core. Expressive Annotations provides new flexible and powerful model validation attributes, to add to the attributes built in to .NET.
     </Description>
 
     <PackageReleaseNotes>
-This release supports client-side validation in .NET Core, using RequiredIf and AssertThat attributes. ToolChain functions and custom-defined functions have not been tested and may not work. 
+This release fixes an issue in 0.1.0 where client-side validation only functioned for one annotation of the same type per property.
     </PackageReleaseNotes>
 
     <Copyright>Copyright 2018 (c) University of Nottingham.</Copyright>

--- a/src/UoN.ExpressiveAnnotations.NetCore/Validators/ExpressiveValidator.cs
+++ b/src/UoN.ExpressiveAnnotations.NetCore/Validators/ExpressiveValidator.cs
@@ -40,8 +40,6 @@ namespace UoN.ExpressiveAnnotations.NetCore.Validators
                 AttributeWeakId = $"{typeof(T).FullName}.{fieldId}".ToLowerInvariant();
                 FieldName = metadata.PropertyName;
 
-                ResetSuffixAllocation();
-
                 var item = ProcessStorage<string, CacheItem>.GetOrAdd(AttributeFullId, _ => // map cache is based on static dictionary, set-up once for entire application instance
                 {                                                                           // (by design, no reason to recompile once compiled expressions)
                     Debug.WriteLine($"[cache add] process: {Process.GetCurrentProcess().Id}, thread: {Thread.CurrentThread.ManagedThreadId}");


### PR DESCRIPTION
Closes #19 

Removed call to reset suffix allocation in ExpressiveValidator base class constructor. This reset was relevant in the Framework version of EA but the Core version constructs client-side validation differently and needs to retain all of the session cache data throughout the session in order to recognise multiple annotations of the same type on a given property and assign them unique IDs.