### PR TITLE
use attribute id if available for weakid to fix arrays validation 27 items

### DIFF
--- a/src/UoN.ExpressiveAnnotations.NetCore/Attributes/AssertThatAttribute.cs
+++ b/src/UoN.ExpressiveAnnotations.NetCore/Attributes/AssertThatAttribute.cs
@@ -80,7 +80,7 @@ namespace UoN.ExpressiveAnnotations.NetCore.Attributes
             var processCache = context.ActionContext.HttpContext.RequestServices.GetService<IMemoryCache>();
             var requestCache = context.ActionContext.HttpContext.RequestServices.GetService<RequestCache>();
 
-            var validator = new AssertThatValidator(context.ModelMetadata, context.Attributes["id"], this, processCache, requestCache);
+            var validator = new AssertThatValidator(context.ModelMetadata, (context.Attributes.ContainsKey("id") ? context.Attributes["id"] : null), this, processCache, requestCache);
             validator.AttachValidationRules(context, DefaultErrorMessage);
         }
     }

--- a/src/UoN.ExpressiveAnnotations.NetCore/Attributes/AssertThatAttribute.cs
+++ b/src/UoN.ExpressiveAnnotations.NetCore/Attributes/AssertThatAttribute.cs
@@ -80,7 +80,7 @@ namespace UoN.ExpressiveAnnotations.NetCore.Attributes
             var processCache = context.ActionContext.HttpContext.RequestServices.GetService<IMemoryCache>();
             var requestCache = context.ActionContext.HttpContext.RequestServices.GetService<RequestCache>();
 
-            var validator = new AssertThatValidator(context.ModelMetadata, this, processCache, requestCache);
+            var validator = new AssertThatValidator(context.ModelMetadata, context.Attributes["id"], this, processCache, requestCache);
             validator.AttachValidationRules(context, DefaultErrorMessage);
         }
     }

--- a/src/UoN.ExpressiveAnnotations.NetCore/Attributes/RequiredIfAttribute.cs
+++ b/src/UoN.ExpressiveAnnotations.NetCore/Attributes/RequiredIfAttribute.cs
@@ -104,7 +104,7 @@ namespace UoN.ExpressiveAnnotations.NetCore.Attributes
             var processCache = context.ActionContext.HttpContext.RequestServices.GetService<IMemoryCache>();
             var requestCache = context.ActionContext.HttpContext.RequestServices.GetService<RequestCache>();
 
-            var validator = new RequiredIfValidator(context.ModelMetadata, context.Attributes["id"], this, processCache, requestCache);
+            var validator = new RequiredIfValidator(context.ModelMetadata, (context.Attributes.ContainsKey("id") ? context.Attributes["id"] : null), this, processCache, requestCache);
             validator.AttachValidationRules(context, DefaultErrorMessage);
         }
     }

--- a/src/UoN.ExpressiveAnnotations.NetCore/Attributes/RequiredIfAttribute.cs
+++ b/src/UoN.ExpressiveAnnotations.NetCore/Attributes/RequiredIfAttribute.cs
@@ -104,7 +104,7 @@ namespace UoN.ExpressiveAnnotations.NetCore.Attributes
             var processCache = context.ActionContext.HttpContext.RequestServices.GetService<IMemoryCache>();
             var requestCache = context.ActionContext.HttpContext.RequestServices.GetService<RequestCache>();
 
-            var validator = new RequiredIfValidator(context.ModelMetadata, this, processCache, requestCache);
+            var validator = new RequiredIfValidator(context.ModelMetadata, context.Attributes["id"], this, processCache, requestCache);
             validator.AttachValidationRules(context, DefaultErrorMessage);
         }
     }

--- a/src/UoN.ExpressiveAnnotations.NetCore/Validators/AssertThatValidator.cs
+++ b/src/UoN.ExpressiveAnnotations.NetCore/Validators/AssertThatValidator.cs
@@ -24,8 +24,8 @@ namespace UoN.ExpressiveAnnotations.NetCore.Validators
         /// <param name="memoryCache">An IMemoryCache instance, scoped to the process.</param>
         /// <param name="requestCache">A RequestCache instance, scoped to the request.</param>
         /// <exception cref="System.ComponentModel.DataAnnotations.ValidationException"></exception>
-        public AssertThatValidator(ModelMetadata metadata, AssertThatAttribute attribute, IMemoryCache memoryCache, IMemoryCache requestCache)
-            : base(metadata, attribute, memoryCache, requestCache)
+        public AssertThatValidator(ModelMetadata metadata, string attributeId, AssertThatAttribute attribute, IMemoryCache memoryCache, IMemoryCache requestCache)
+            : base(metadata, attributeId, attribute, memoryCache, requestCache)
         {
         }
 

--- a/src/UoN.ExpressiveAnnotations.NetCore/Validators/ExpressiveValidator.cs
+++ b/src/UoN.ExpressiveAnnotations.NetCore/Validators/ExpressiveValidator.cs
@@ -35,7 +35,7 @@ namespace UoN.ExpressiveAnnotations.NetCore.Validators
         /// <param name="processCache">An IMemoryCache instance, scoped to the process.</param>
         /// <param name="requestCache">A RequestCache instance, scoped to the request.</param>
         /// <exception cref="System.ComponentModel.DataAnnotations.ValidationException"></exception>
-        protected ExpressiveValidator(ModelMetadata metadata, T attribute, IMemoryCache processCache, IMemoryCache requestCache)
+        protected ExpressiveValidator(ModelMetadata metadata, string attributeId, T attribute, IMemoryCache processCache, IMemoryCache requestCache)
         {
             _requestCache = requestCache;
 
@@ -43,7 +43,8 @@ namespace UoN.ExpressiveAnnotations.NetCore.Validators
             {
                 Debug.WriteLine($"[ctor entry] process: {Process.GetCurrentProcess().Id}, thread: {Thread.CurrentThread.ManagedThreadId}");
 
-                var fieldId = $"{metadata.ContainerType.FullName}.{metadata.PropertyName}".ToLowerInvariant();
+                var propertytName = string.IsNullOrEmpty(attributeId) ? metadata.PropertyName : attributeId;
+                var fieldId = $"{metadata.ContainerType.FullName}.{propertytName}".ToLowerInvariant();
                 AttributeFullId = $"{attribute.TypeId}.{fieldId}".ToLowerInvariant();
                 AttributeWeakId = $"{typeof(T).FullName}.{fieldId}".ToLowerInvariant();
                 FieldName = metadata.PropertyName;

--- a/src/UoN.ExpressiveAnnotations.NetCore/Validators/RequiredIfValidator.cs
+++ b/src/UoN.ExpressiveAnnotations.NetCore/Validators/RequiredIfValidator.cs
@@ -26,8 +26,8 @@ namespace UoN.ExpressiveAnnotations.NetCore.Validators
         /// <param name="memoryCache">An IMemoryCache instance, scoped to the process.</param>
         /// <param name="requestCache">A RequestCache instance, scoped to the request.</param>
         /// <exception cref="System.ComponentModel.DataAnnotations.ValidationException"></exception>
-        public RequiredIfValidator(ModelMetadata metadata, RequiredIfAttribute attribute, IMemoryCache memoryCache, IMemoryCache requestCache)
-            : base(metadata, attribute, memoryCache, requestCache)
+        public RequiredIfValidator(ModelMetadata metadata, string attributeId, RequiredIfAttribute attribute, IMemoryCache memoryCache, IMemoryCache requestCache)
+            : base(metadata, attributeId, attribute, memoryCache, requestCache)
         {
             AllowEmpty = attribute.AllowEmptyStrings;
 


### PR DESCRIPTION
fix for #31 when using arrays of data preventing validation working as weakid sees each as same id.